### PR TITLE
Add support for "new-button"

### DIFF
--- a/data.go
+++ b/data.go
@@ -3434,9 +3434,9 @@ var (
 			SubGroup:    "alphanum",
 		},
 
-		"🆕": {
+		"🆕️": {
 			Slug:        "new-button",
-			Character:   "🆕",
+			Character:   "🆕️",
 			UnicodeName: "E0.6 NEW button",
 			CodePoint:   "1F195",
 			Group:       "Symbols",

--- a/data.go
+++ b/data.go
@@ -42241,14 +42241,5 @@ var (
 			Group:       "People & Body",
 			SubGroup:    "hands",
 		},
-
-		"🆕️": {
-			Slug:        "new-button",
-			Character:   "🆕️",
-			UnicodeName: "?",
-			CodePoint:   "1F195",
-			Group:       "Symbols",
-			SubGroup:    "alphanum",
-		},
 	}
 )

--- a/data.go
+++ b/data.go
@@ -42241,5 +42241,14 @@ var (
 			Group:       "People & Body",
 			SubGroup:    "hands",
 		},
+
+		"🆕️": {
+			Slug:        "new-button",
+			Character:   "🆕️",
+			UnicodeName: "?",
+			CodePoint:   "1F195",
+			Group:       "Symbols",
+			SubGroup:    "alphanum",
+		},
 	}
 )

--- a/gomoji_test.go
+++ b/gomoji_test.go
@@ -76,6 +76,11 @@ func TestContainsEmoji(t *testing.T) {
 			inputStr: "Just type #",
 			want:     false,
 		},
+		{
+			name:     "new emoji",
+			inputStr: "🆕️ NWT H&M Corduroy Pants in 'Light Beige'",
+			want:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -135,6 +140,11 @@ func TestRemoveEmojis(t *testing.T) {
 			name:     "remove rare emojis",
 			inputStr: "🧖 hello 🦋world",
 			want:     "hello world",
+		},
+		{
+			name:     "remove new emoji",
+			inputStr: "🆕️ NWT H&M Corduroy Pants in 'Light Beige'",
+			want:     "NWT H&M Corduroy Pants in 'Light Beige'",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Seems like 🆕 is not included in the list ([ref](https://emojipedia.org/new-button/)).

@forPelevin I don't know what to put in `UnicodeName` so I left a ? for now, let me know what to put there.
