### PR TITLE
Added collect all function to find all emojis in a string without eliminating duplicates

### DIFF
--- a/gomoji.go
+++ b/gomoji.go
@@ -85,37 +85,21 @@ func GetInfo(emoji string) (Emoji, error) {
 // CollectAll finds all emojis in given string. Unlike FindAll, this does not
 // distinct repeating occurrences of emoji. If there are no emojis it returns a nil-slice.
 func CollectAll(s string) []Emoji {
-	var emojis []Emoji
 
-	lastSeen := 0
+	var emojis []Emoji
 
 	gr := uniseg.NewGraphemes(s)
 	for gr.Next() {
+		if em, ok := emojiMap[gr.Str()]; ok {
+			emojis = append(emojis, em)
+			continue
+		}
 
 		start, end := gr.Positions()
-
-		for _, r := range s[lastSeen:start] {
+		for _, r := range s[start:end] {
 			if em, ok := emojiMap[string(r)]; ok {
 				emojis = append(emojis, em)
 			}
-		}
-
-		if em, ok := emojiMap[gr.Str()]; ok {
-			emojis = append(emojis, em)
-		} else {
-			for _, r := range s[start:end] {
-				if em, ok := emojiMap[string(r)]; ok {
-					emojis = append(emojis, em)
-				}
-			}
-		}
-
-		lastSeen = end
-	}
-
-	for _, r := range s[lastSeen:] {
-		if em, ok := emojiMap[string(r)]; ok {
-			emojis = append(emojis, em)
 		}
 	}
 

--- a/gomoji.go
+++ b/gomoji.go
@@ -83,18 +83,37 @@ func GetInfo(emoji string) (Emoji, error) {
 }
 
 // CollectAll finds all emojis in given string. Unlike FindAll, this does not
-// distinct repeating occurrences of emoji.
+// distinct repeating occurrences of emoji. If there are no emojis it returns a nil-slice.
 func CollectAll(s string) []Emoji {
-	emojis := []Emoji{}
+	var emojis []Emoji
+
+	lastSeen := 0
 
 	gr := uniseg.NewGraphemes(s)
 	for gr.Next() {
+
+		start, end := gr.Positions()
+
+		for _, r := range s[lastSeen:start] {
+			if em, ok := emojiMap[string(r)]; ok {
+				emojis = append(emojis, em)
+			}
+		}
+
 		if em, ok := emojiMap[gr.Str()]; ok {
 			emojis = append(emojis, em)
+		} else {
+			for _, r := range s[start:end] {
+				if em, ok := emojiMap[string(r)]; ok {
+					emojis = append(emojis, em)
+				}
+			}
 		}
+
+		lastSeen = end
 	}
 
-	for _, r := range s {
+	for _, r := range s[lastSeen:] {
 		if em, ok := emojiMap[string(r)]; ok {
 			emojis = append(emojis, em)
 		}

--- a/gomoji.go
+++ b/gomoji.go
@@ -82,6 +82,27 @@ func GetInfo(emoji string) (Emoji, error) {
 	return em, nil
 }
 
+// CollectAll finds all emojis in given string. Unlike FindAll, this does not
+// distinct repeating occurrences of emoji.
+func CollectAll(s string) []Emoji {
+	emojis := []Emoji{}
+
+	gr := uniseg.NewGraphemes(s)
+	for gr.Next() {
+		if em, ok := emojiMap[gr.Str()]; ok {
+			emojis = append(emojis, em)
+		}
+	}
+
+	for _, r := range s {
+		if em, ok := emojiMap[string(r)]; ok {
+			emojis = append(emojis, em)
+		}
+	}
+
+	return emojis
+}
+
 // FindAll finds all emojis in given string. If there are no emojis it returns a nil-slice.
 func FindAll(s string) []Emoji {
 	emojis := make(map[string]Emoji)

--- a/gomoji_test.go
+++ b/gomoji_test.go
@@ -277,7 +277,7 @@ func TestFindAll(t *testing.T) {
 			},
 		},
 		{
-			name:     "string with 2 emoji",
+			name:     "string with 1 emoji",
 			inputStr: "🆕️ NWT H&M Corduroy Pants in 'Light Beige'",
 			want: []Emoji{
 				{
@@ -311,5 +311,121 @@ func BenchmarkFindAllParallel(b *testing.B) {
 func BenchmarkFindAll(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		FindAll("\U0001F96F Hi \U0001F970")
+	}
+}
+
+func TestCollectAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputStr string
+		want     []Emoji
+	}{
+		{
+			name:     "empty string",
+			inputStr: "",
+			want:     nil,
+		},
+		{
+			name:     "string without emoji",
+			inputStr: "hello world",
+			want:     nil,
+		},
+		{
+			name:     "string with 2 emoji",
+			inputStr: "hello 🦋 world \U0001F9FB",
+			want: []Emoji{
+				{
+					Slug:        "butterfly",
+					Character:   "🦋",
+					UnicodeName: "E3.0 butterfly",
+					CodePoint:   "1F98B",
+					Group:       "Animals & Nature",
+					SubGroup:    "animal-bug",
+				},
+				{
+					Slug:        "roll-of-paper",
+					Character:   "🧻",
+					UnicodeName: "E11.0 roll of paper",
+					CodePoint:   "1F9FB",
+					Group:       "Objects",
+					SubGroup:    "household",
+				},
+			},
+		},
+		{
+			name:     "string with 1 emoji",
+			inputStr: "🆕️ NWT H&M Corduroy Pants in 'Light Beige'",
+			want: []Emoji{
+				{
+					Slug:        "new-button",
+					Character:   "🆕",
+					UnicodeName: "E0.6 NEW button",
+					CodePoint:   "1F195",
+					Group:       "Symbols",
+					SubGroup:    "alphanum",
+				},
+			},
+		},
+		{
+			name:     "string with 6 emoji, mixed and repeating",
+			inputStr: "🆕️ NWT H&M Corduroy 🧻🦋🧻 Pants in 'Light Beige'🦋🆕",
+			want: []Emoji{
+				{
+					Slug:        "new-button",
+					Character:   "🆕",
+					UnicodeName: "E0.6 NEW button",
+					CodePoint:   "1F195",
+					Group:       "Symbols",
+					SubGroup:    "alphanum",
+				},
+				{
+					Slug:        "roll-of-paper",
+					Character:   "🧻",
+					UnicodeName: "E11.0 roll of paper",
+					CodePoint:   "1F9FB",
+					Group:       "Objects",
+					SubGroup:    "household",
+				},
+				{
+					Slug:        "butterfly",
+					Character:   "🦋",
+					UnicodeName: "E3.0 butterfly",
+					CodePoint:   "1F98B",
+					Group:       "Animals & Nature",
+					SubGroup:    "animal-bug",
+				},
+				{
+					Slug:        "roll-of-paper",
+					Character:   "🧻",
+					UnicodeName: "E11.0 roll of paper",
+					CodePoint:   "1F9FB",
+					Group:       "Objects",
+					SubGroup:    "household",
+				},
+				{
+					Slug:        "butterfly",
+					Character:   "🦋",
+					UnicodeName: "E3.0 butterfly",
+					CodePoint:   "1F98B",
+					Group:       "Animals & Nature",
+					SubGroup:    "animal-bug",
+				},
+				{
+					Slug:        "new-button",
+					Character:   "🆕",
+					UnicodeName: "E0.6 NEW button",
+					CodePoint:   "1F195",
+					Group:       "Symbols",
+					SubGroup:    "alphanum",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CollectAll(tt.inputStr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CollectAll() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
I really wanted to use gomoji but it's missing a way to collect all emojis in a string as-is, without ignoring repeating emojis.

I am building a service that analyzes emojis in strings and need a way to detect which emojis appear and how many times.

I also feel like this behavior is more suiting the name `FindAll` and the current behavior of `FindAll` should be relocated to a `FindAllDistinct`.